### PR TITLE
refactor: change schema name to reflect name of project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # pg_acm
 
-## Description 
+## Description
 
-`pg_acm` is a tools for access control management. 
+`pg_acm` is a tools for access control management.
 
 I encorage everyone interested to try it, and if you find it useful, please help me to advocated to add this functionality to Postgres!
 
@@ -25,7 +25,7 @@ alter database my_db owner to mydb_owner;
 * invoke pg_acm by running as a superuser:
 
 ```
-select * from acm_tools.enable_security();
+select * from pg_acm.enable_security();
 
 ```
 **For detailed functionality description, please refer to the User Manual.**

--- a/_load_all.sql
+++ b/_load_all.sql
@@ -1,5 +1,5 @@
 begin;
- create schema if not exists acm_tools;
+ create schema if not exists pg_acm;
 
 \ir sql/tables/allowed_role.sql
 \ir sql/tables/account_role.sql
@@ -13,7 +13,7 @@ begin;
 \ir sql/functions/drop_schema_roles_sd.sql
 \ir sql/functions/create_role.sql
 \ir sql/functions/create_role_for_schema.sql
-\ir sql/functions/assign_account_role.sql 
+\ir sql/functions/assign_account_role.sql
 \ir sql/functions/assign_role.sql
 \ir sql/functions/assign_schema_app_role.sql
 \ir sql/functions/assign_schema_role_sd.sql
@@ -41,14 +41,13 @@ begin
   where
     evtname = 'fix_perm_after';
   if v_cnt > 0 then
-     perform acm_tools.enable_security;
-  end if;  
-   for v_rec in (select substr(account_role_name, 1, length(account_role_name)-position (reverse('_owner') in reverse(account_role_name))-6) as account 
-                from acm_tools.account_role) 
+     perform pg_acm.enable_security;
+  end if;
+   for v_rec in (select substr(account_role_name, 1, length(account_role_name)-position (reverse('_owner') in reverse(account_role_name))-6) as account
+                from pg_acm.account_role)
      loop
-        perform acm_tools.perm_create_cust_account(v_rec.account);
+        perform pg_acm.perm_create_cust_account(v_rec.account);
     end loop;
 end;
 $$;
 commit;
-

--- a/acm_tools_user_guide.md
+++ b/acm_tools_user_guide.md
@@ -1,25 +1,25 @@
-# acm_tools User Guide
+# pg_acm User Guide
 
 ## Functions provided
 
 | Function name | Description | Permissions Needed |
 |---------------|-------------|--------------------|
-| `acm_tools.perm_create_cust_account(account_name)` | creates a new account | `database owner` |
-| `acm_tools.perm_drop_cust_account(account_name)` | drops an account | `database owner` |
-| `acm_tools.perm_assign_schema_schema_owner_role(schema_name, schema_owner_name, schema_owner_password)` | assigns schema owner roles to users| `account owner` |
-| `acm_tools.perm_revoke_schema_schema_owner_role(schema_name, schema_owner_name)` | revokes schema owner roles from users | `account owner` |
-| `acm_tools.perm_assign_account_role(account_name, role_name, role_password)` | assigns account owner roles to users | `account owner` |
-| `acm_tools.perm_assign_schema_app_role(schema_name, app_user_name, app_user_password)` | assigns read_write roles to users | `account owner` |
-| `acm_tools.perm_revoke_schema_app_role(schema_name, app_user_name)` | revokes read_write roles from users | `account owner` |
-| `acm_tools.perm_assign_schema_ro_role(schema_name, ro_user_name, ro_user_password)` | assigns read_only roles to users | `account owner` |
-| `acm_tools.perm_revoke_schema_ro_role(schema_name, ro_user_name)` | revokes read_only roles from users  | `account owner` |
+| `pg_acm.perm_create_cust_account(account_name)` | creates a new account | `database owner` |
+| `pg_acm.perm_drop_cust_account(account_name)` | drops an account | `database owner` |
+| `pg_acm.perm_assign_schema_schema_owner_role(schema_name, schema_owner_name, schema_owner_password)` | assigns schema owner roles to users| `account owner` |
+| `pg_acm.perm_revoke_schema_schema_owner_role(schema_name, schema_owner_name)` | revokes schema owner roles from users | `account owner` |
+| `pg_acm.perm_assign_account_role(account_name, role_name, role_password)` | assigns account owner roles to users | `account owner` |
+| `pg_acm.perm_assign_schema_app_role(schema_name, app_user_name, app_user_password)` | assigns read_write roles to users | `account owner` |
+| `pg_acm.perm_revoke_schema_app_role(schema_name, app_user_name)` | revokes read_write roles from users | `account owner` |
+| `pg_acm.perm_assign_schema_ro_role(schema_name, ro_user_name, ro_user_password)` | assigns read_only roles to users | `account owner` |
+| `pg_acm.perm_revoke_schema_ro_role(schema_name, ro_user_name)` | revokes read_only roles from users  | `account owner` |
 
 ## How to use
 
 ### Create new account
 
 ```
-SELECT * FROM acm_tools.create_cust_account (
+SELECT * FROM pg_acm.create_cust_account (
   'account1'
 );
 ```
@@ -28,7 +28,7 @@ SELECT * FROM acm_tools.create_cust_account (
 ### Create a user for an account
 
 ```
-SELECT * FROM acm_tools.assign_account_role(
+SELECT * FROM pg_acm.assign_account_role(
 	p_account_name => 'account1',
 	p_acct_user => 'acct_user1',
 	p_acct_user_password => 'acct_user_pwd'
@@ -56,19 +56,19 @@ Additional functions allow granting these roles to users.
 In each case, a corresponding function would check whether the user exists, and create it if it doesn't exist, and assign the corresponding privilege and the search_path. If the user already exists, the password is not needed, and will be ignored if provided.
 
 ```
-SELECT * FROM acm_tools.assign_schema_app_role (
+SELECT * FROM pg_acm.assign_schema_app_role (
   'schema_name',
   'app_user_name',
   'app_user_password'
 );
 
-SELECT * FROM acm_tools.assign_schema_schema_owner_role (
+SELECT * FROM pg_acm.assign_schema_schema_owner_role (
   'schema_name',
   'schema_owner_user_name',
   'schema_owner_password'
 );
 
-SELECT * FROM acm_tools.assign_schema_ro_role (
+SELECT * FROM pg_acm.assign_schema_ro_role (
   'schema_name',
   'ro_user_name',
   'ro_user_password'
@@ -86,7 +86,7 @@ All ```assign``` functions have an additional boolean parameter p_update_search_
 New app user, don't update search path
 
 ```
-SELECT * FROM acm_tools.assign_schema_app_role (
+SELECT * FROM pg_acm.assign_schema_app_role (
   'schema_name',
   'app_user_name',
   'app_user_password',
@@ -97,7 +97,7 @@ SELECT * FROM acm_tools.assign_schema_app_role (
 Existing user, update the search path:
 
 ```
-SELECT * FROM acm_tools.assign_schema_ro_role (
+SELECT * FROM pg_acm.assign_schema_ro_role (
   'schema_name',
   'ro_user_name',
   null,
@@ -108,17 +108,17 @@ SELECT * FROM acm_tools.assign_schema_ro_role (
 ### Matching “revoke” functions for each user category
 
 ```
-SELECT * FROM acm_tools.revoke_schema_app_role (
+SELECT * FROM pg_acm.revoke_schema_app_role (
   'schema_name',
   'app_user_name'
 );
 
-SELECT * FROM acm_tools.revoke_schema_schema_owner_role (
+SELECT * FROM pg_acm.revoke_schema_schema_owner_role (
   'schema_name',
   'schema_owner_user_name'
 );
 
-SELECT * FROM acm_tools.revoke_schema_ro_role (
+SELECT * FROM pg_acm.revoke_schema_ro_role (
   'schema_name',
   'ro_user_name'
 );
@@ -128,13 +128,13 @@ SELECT * FROM acm_tools.revoke_schema_ro_role (
 
 |Function name | Description | Permissions Needed |
 |---------------|-------------|--------------------|
-| `acm_tools.create_role('new_role')` | Creates a new role without permissions| `database owner` |
-| `acm_tools.assign_role('new_role','new_user','passwd')` | grants previously created role to a new or existing user; leave password null fo existing user | `database owner` |
+| `pg_acm.create_role('new_role')` | Creates a new role without permissions| `database owner` |
+| `pg_acm.assign_role('new_role','new_user','passwd')` | grants previously created role to a new or existing user; leave password null fo existing user | `database owner` |
 
 ## Other administrative functions
 
 | Function name | Description | Permissions Needed |
 |---------------|-------------|--------------------|
-| `acm_tools.terminate_process(pid)` | kills any non-superuser session | `database owner` |
-| `acm_tools.db_direct_privs_select()` | lists all directly granted privileges | `database owner` |
-| `acm_tools.db_all_privs_select()` | lists all atomic privileges for all db users | `database owner` |
+| `pg_acm.terminate_process(pid)` | kills any non-superuser session | `database owner` |
+| `pg_acm.db_direct_privs_select()` | lists all directly granted privileges | `database owner` |
+| `pg_acm.db_all_privs_select()` | lists all atomic privileges for all db users | `database owner` |

--- a/sql/functions/assign_account_role.sql
+++ b/sql/functions/assign_account_role.sql
@@ -1,4 +1,4 @@
-create or replace function acm_tools.assign_account_role(p_account_name text,
+create or replace function pg_acm.assign_account_role(p_account_name text,
 p_acct_user text,
 p_acct_user_password text default null)
 RETURNS text
@@ -8,7 +8,7 @@ DECLARE
 v_sql text;
 v_cnt int;
 BEGIN
-  select count(*) into v_cnt from acm_tools.account_role where account_role_name=p_account_name||'_owner';
+  select count(*) into v_cnt from pg_acm.account_role where account_role_name=p_account_name||'_owner';
   if v_cnt=0 then
      raise exception 'Account % does not exist', p_account_name;
   end if;
@@ -32,4 +32,4 @@ BEGIN
 END;
 $func$
 language plpgsql security definer;
-revoke execute on function acm_tools.assign_account_role from public;
+revoke execute on function pg_acm.assign_account_role from public;

--- a/sql/functions/assign_role.sql
+++ b/sql/functions/assign_role.sql
@@ -1,4 +1,4 @@
-create or replace function acm_tools.assign_role(p_role_name text,
+create or replace function pg_acm.assign_role(p_role_name text,
 p_user text,
 p_password text default null)
 
@@ -9,7 +9,7 @@ DECLARE
 v_sql text;
 v_cnt int;
 BEGIN
-   select count(*) into v_cnt from acm_tools.allowed_role where role_name=p_role_name;
+   select count(*) into v_cnt from pg_acm.allowed_role where role_name=p_role_name;
     if v_cnt=0 then
        raise exception 'Role % is not allowed', p_role_name;
   end if;
@@ -33,5 +33,4 @@ BEGIN
 END;
 $func$
 language plpgsql security definer;
-revoke execute on function acm_tools.assign_role from public;
-
+revoke execute on function pg_acm.assign_role from public;

--- a/sql/functions/assign_schema_app_role.sql
+++ b/sql/functions/assign_schema_app_role.sql
@@ -1,5 +1,5 @@
-drop function if exists acm_tools.assign_schema_app_role (text, text,text);
-create or replace function acm_tools.assign_schema_app_role (p_schema_name text,
+drop function if exists pg_acm.assign_schema_app_role (text, text,text);
+create or replace function pg_acm.assign_schema_app_role (p_schema_name text,
 p_srv_user text,
 p_password text default null,
 p_update_search_path boolean default true
@@ -10,9 +10,8 @@ $si$
 declare
 v_sql text;
 begin
-  select acm_tools.assign_schema_role (p_schema_name, 'read_write',p_srv_user,p_password,p_update_search_path )
+  select pg_acm.assign_schema_role (p_schema_name, 'read_write',p_srv_user,p_password,p_update_search_path )
   into v_sql;
 return v_sql;
 end; $si$;
-revoke execute on function acm_tools.assign_schema_app_role from public;
-
+revoke execute on function pg_acm.assign_schema_app_role from public;

--- a/sql/functions/assign_schema_ro_role.sql
+++ b/sql/functions/assign_schema_ro_role.sql
@@ -1,6 +1,6 @@
-drop function if exists acm_tools.assign_schema_ro_role (text, text, text);
+drop function if exists pg_acm.assign_schema_ro_role (text, text, text);
 
-create or replace function acm_tools.assign_schema_ro_role (p_schema_name text,
+create or replace function pg_acm.assign_schema_ro_role (p_schema_name text,
   p_ro_user text,
   p_password text default null,
   p_update_search_path boolean default true)
@@ -10,9 +10,9 @@ $si$
 declare
   v_sql text;
 begin
-  select acm_tools.assign_schema_role (p_schema_name, 'read_only',p_ro_user,p_password,p_update_search_path)
+  select pg_acm.assign_schema_role (p_schema_name, 'read_only',p_ro_user,p_password,p_update_search_path)
      into v_sql;
   return v_sql;
 end; $si$;
 
-revoke execute on function acm_tools.assign_schema_ro_role from public;
+revoke execute on function pg_acm.assign_schema_ro_role from public;

--- a/sql/functions/assign_schema_role.sql
+++ b/sql/functions/assign_schema_role.sql
@@ -1,6 +1,6 @@
-drop function if exists acm_tools.assign_schema_role(text, text, text, text);
+drop function if exists pg_acm.assign_schema_role(text, text, text, text);
 
-create or replace function acm_tools.assign_schema_role (p_schema_name text,
+create or replace function pg_acm.assign_schema_role (p_schema_name text,
 p_role text,
 p_srv_user text,
 p_password text default null,
@@ -11,8 +11,8 @@ $si$
 declare
 v_sql text;
 begin
-  if acm_tools.check_schema_perm(p_schema_name) then
-    select acm_tools.assign_schema_role_sd (
+  if pg_acm.check_schema_perm(p_schema_name) then
+    select pg_acm.assign_schema_role_sd (
             p_schema_name,
             p_role,
             p_srv_user,
@@ -23,4 +23,4 @@ begin
      raise exception 'You are not allowed to assign roles in schema %', p_schema_name;
  end if;
 end; $si$;
-revoke execute on function acm_tools.assign_schema_role from public;
+revoke execute on function pg_acm.assign_schema_role from public;

--- a/sql/functions/assign_schema_role_sd.sql
+++ b/sql/functions/assign_schema_role_sd.sql
@@ -1,6 +1,6 @@
-drop function if exists acm_tools.assign_schema_role_sd (text, text,text,text);
+drop function if exists pg_acm.assign_schema_role_sd (text, text,text,text);
 
-create or replace function acm_tools.assign_schema_role_sd (p_schema_name text,
+create or replace function pg_acm.assign_schema_role_sd (p_schema_name text,
 p_role text,
 p_srv_user text,
 p_password text default null,
@@ -13,8 +13,8 @@ v_sql text;
 v_cnt int;
 v_role_name text;
 BEGIN
-  if not acm_tools.check_stack('acm_tools.assign_schema_role ')
-    and not acm_tools.check_stack('acm_tools.create_schema_roles')
+  if not pg_acm.check_stack('pg_acm.assign_schema_role ')
+    and not pg_acm.check_stack('pg_acm.create_schema_roles')
      then
      raise exception 'You are not allowed to assign roles in schema %', p_schema_name;
   end if;
@@ -47,4 +47,4 @@ END;
 $func$
 language plpgsql security definer;
 
-revoke execute on function acm_tools.assign_schema_role_sd (text, text,text,text,boolean) from public;
+revoke execute on function pg_acm.assign_schema_role_sd (text, text,text,text,boolean) from public;

--- a/sql/functions/assign_schema_schema_owner_role.sql
+++ b/sql/functions/assign_schema_schema_owner_role.sql
@@ -1,5 +1,5 @@
-drop function if exists acm_tools.assign_schema_schema_owner_role (text, text, text);
-create or replace function acm_tools.assign_schema_schema_owner_role (p_schema_name text,
+drop function if exists pg_acm.assign_schema_schema_owner_role (text, text, text);
+create or replace function pg_acm.assign_schema_schema_owner_role (p_schema_name text,
   p_srv_user text,
   p_password text default null,
   p_update_search_path boolean default true)
@@ -8,8 +8,8 @@ returns text language plpgsql as
 $si$
 declare v_sql text;
 begin
-select acm_tools.assign_schema_role (p_schema_name, 'schema_owner',p_srv_user,p_password,p_update_search_path)
+select pg_acm.assign_schema_role (p_schema_name, 'schema_owner',p_srv_user,p_password,p_update_search_path)
 into v_sql;
 return v_sql;
 end; $si$;
-revoke execute on function acm_tools.assign_schema_schema_owner_role from public;
+revoke execute on function pg_acm.assign_schema_schema_owner_role from public;

--- a/sql/functions/check_schema_perm.sql
+++ b/sql/functions/check_schema_perm.sql
@@ -1,4 +1,4 @@
-create or replace function acm_tools.check_schema_perm(p_schema_name text)
+create or replace function pg_acm.check_schema_perm(p_schema_name text)
 returns boolean language sql
 as
 $$
@@ -27,4 +27,4 @@ select
 );
 $$;
 
-revoke execute on function acm_tools.check_schema_perm from public;
+revoke execute on function pg_acm.check_schema_perm from public;

--- a/sql/functions/check_stack.sql
+++ b/sql/functions/check_stack.sql
@@ -1,4 +1,4 @@
-create or replace function acm_tools.check_stack(p_outer_function text)
+create or replace function pg_acm.check_stack(p_outer_function text)
 returns boolean
 as $func$
 declare
@@ -8,4 +8,4 @@ begin
  return  (position (p_outer_function in v_stack)>0);
 end;
 $func$ language plpgsql security definer;
-revoke execute on function acm_tools.check_stack from public;
+revoke execute on function pg_acm.check_stack from public;

--- a/sql/functions/create_cust_account.sql
+++ b/sql/functions/create_cust_account.sql
@@ -1,4 +1,4 @@
-create or replace function acm_tools.create_cust_account (p_acct_name text)
+create or replace function pg_acm.create_cust_account (p_acct_name text)
 returns text
 language plpgsql security definer
 as $body$
@@ -17,27 +17,27 @@ begin
   if v_cnt=0 then --new role
     execute $$create role $$|| v_sql_role;
   end if;
-  insert into acm_tools.account_role values (v_sql_role) on conflict do nothing;
+  insert into pg_acm.account_role values (v_sql_role) on conflict do nothing;
   v_sql:=format($sql$
-  grant usage on schema acm_tools to %s;
-  grant select on acm_tools.account_role to %s;
+  grant usage on schema pg_acm to %s;
+  grant select on pg_acm.account_role to %s;
   grant %s to %s;
-  grant execute on function acm_tools.check_schema_perm to %s;
-  grant execute on function acm_tools.check_stack to %s;
-  grant execute on function acm_tools.create_schema to %s;
-  grant execute on function acm_tools.create_schema_sd to %s;
-  grant execute on function acm_tools.create_role_for_schema to %s;
-  grant execute on function acm_tools.drop_schema_roles_sd to %s;
-  grant execute on function acm_tools.assign_schema_role to %s;
-  grant execute on function acm_tools.assign_schema_role_sd to %s;
-  grant execute on function acm_tools.revoke_role to %s;
-  grant execute on function acm_tools.revoke_role_sd to %s;
-  grant execute on function acm_tools.assign_schema_app_role to %s;
-  grant execute on function acm_tools.assign_schema_schema_owner_role to %s;
-  grant execute on function acm_tools.assign_schema_ro_role to %s;
-  grant execute on function acm_tools.revoke_schema_app_role to %s;
-  grant execute on function acm_tools.revoke_schema_schema_owner_role to %s;
-  grant execute on function acm_tools.revoke_schema_ro_role to %s;
+  grant execute on function pg_acm.check_schema_perm to %s;
+  grant execute on function pg_acm.check_stack to %s;
+  grant execute on function pg_acm.create_schema to %s;
+  grant execute on function pg_acm.create_schema_sd to %s;
+  grant execute on function pg_acm.create_role_for_schema to %s;
+  grant execute on function pg_acm.drop_schema_roles_sd to %s;
+  grant execute on function pg_acm.assign_schema_role to %s;
+  grant execute on function pg_acm.assign_schema_role_sd to %s;
+  grant execute on function pg_acm.revoke_role to %s;
+  grant execute on function pg_acm.revoke_role_sd to %s;
+  grant execute on function pg_acm.assign_schema_app_role to %s;
+  grant execute on function pg_acm.assign_schema_schema_owner_role to %s;
+  grant execute on function pg_acm.assign_schema_ro_role to %s;
+  grant execute on function pg_acm.revoke_schema_app_role to %s;
+  grant execute on function pg_acm.revoke_schema_schema_owner_role to %s;
+  grant execute on function pg_acm.revoke_schema_ro_role to %s;
   grant create on database %s to %s;
   $sql$,
   v_sql_role,
@@ -66,4 +66,4 @@ begin
  execute v_sql;
 return v_sql;
 end; $body$;
-revoke execute on function acm_tools.create_cust_account from public;
+revoke execute on function pg_acm.create_cust_account from public;

--- a/sql/functions/create_role.sql
+++ b/sql/functions/create_role.sql
@@ -1,4 +1,4 @@
-create or replace function acm_tools.create_role(p_role_name text)
+create or replace function pg_acm.create_role(p_role_name text)
 
 RETURNS text
 AS
@@ -7,11 +7,11 @@ DECLARE
 v_sql text;
 v_cnt int;
 BEGIN
-   select count(*) into v_cnt from acm_tools.allowed_role where role_name=p_role_name;
+   select count(*) into v_cnt from pg_acm.allowed_role where role_name=p_role_name;
     if v_cnt>0 then
        raise exception 'Role % already exists', p_role_name;
     else
-       insert into acm_tools.allowed_role (role_name) values (p_role_name);
+       insert into pg_acm.allowed_role (role_name) values (p_role_name);
   end if;
   select count(*) into v_cnt from pg_authid where rolname=p_role_name;
   if v_cnt>0 then
@@ -24,5 +24,4 @@ BEGIN
 END;
 $func$
 language plpgsql security definer;
-revoke execute on function acm_tools.create_role(text) from public;
-
+revoke execute on function pg_acm.create_role(text) from public;

--- a/sql/functions/create_role_for_schema.sql
+++ b/sql/functions/create_role_for_schema.sql
@@ -1,4 +1,4 @@
-create or replace function acm_tools.create_role_for_schema(
+create or replace function pg_acm.create_role_for_schema(
   p_schema_name text,
   p_select boolean default false,
   p_insert boolean default false,
@@ -78,11 +78,11 @@ BEGIN
   v_sql_grant:=substr(v_sql_grant,1,length(v_sql_grant)-1);
   v_sql_default:=substr(v_sql_default,1,length(v_sql_default)-1);
 
-  select count(*) into v_cnt from acm_tools.allowed_role where role_name=v_role_name;
+  select count(*) into v_cnt from pg_acm.allowed_role where role_name=v_role_name;
   if v_cnt>0 then
     raise exception 'Role % already exists', v_role_name;
   else
-    insert into acm_tools.allowed_role (role_name) values (v_role_name);
+    insert into pg_acm.allowed_role (role_name) values (v_role_name);
   end if;
 
   select count(*) into v_cnt from pg_authid where rolname=v_role_name;
@@ -108,5 +108,4 @@ BEGIN
 END;
 $func$
 language plpgsql security definer;
-revoke execute on function acm_tools.create_role_for_schema (text, boolean, boolean, boolean, boolean, boolean) from public;
-
+revoke execute on function pg_acm.create_role_for_schema (text, boolean, boolean, boolean, boolean, boolean) from public;

--- a/sql/functions/create_schema.sql
+++ b/sql/functions/create_schema.sql
@@ -1,4 +1,4 @@
-create or replace function acm_tools.create_schema(
+create or replace function pg_acm.create_schema(
    p_schema_name text)
 --security invoker
 returns text
@@ -29,10 +29,10 @@ begin
             select member::text, role::text
               from x
               where member::text=current_user
-                and role::text in (select account_role_name from acm_tools.account_role)
+                and role::text in (select account_role_name from pg_acm.account_role)
             union
             select account_role_name, account_role_name
-              from acm_tools.account_role
+              from pg_acm.account_role
               where account_role_name=current_user
            ) a;
     case (v_cnt)
@@ -52,20 +52,19 @@ begin
             select distinct substr(role::text,1, length(role::text)-6) into v_account
               from  (select member::text, role::text from x
               where member::text=current_user
-                and role::text in (select account_role_name from acm_tools.account_role)
+                and role::text in (select account_role_name from pg_acm.account_role)
             union
             select account_role_name, account_role_name
-              from acm_tools.account_role
+              from pg_acm.account_role
               where account_role_name=current_user
           ) a;
       else
         raise exception 'Please switch to account onwer role to create schema %', p_schema_name;
     end case;
     v_schema_admin :=v_account||'_owner';
-  return (select acm_tools.create_schema_sd(
+  return (select pg_acm.create_schema_sd(
               p_schema_name,
               v_schema_admin,
               v_schema_owner_setting));
   end;
 $create_schema$;
-

--- a/sql/functions/create_schema_sd.sql
+++ b/sql/functions/create_schema_sd.sql
@@ -1,4 +1,4 @@
-create or replace function acm_tools.create_schema_sd (
+create or replace function pg_acm.create_schema_sd (
    p_schema_name text,
    p_schema_admin text,
    p_schema_owner_setting boolean)
@@ -15,7 +15,7 @@ DECLARE
    v_read_only_role text:=p_schema_name||'_read_only';
    v_read_write_role text:=p_schema_name||'_read_write';
 BEGIN
-  if not acm_tools.check_stack('acm_tools.create_schema') then
+  if not pg_acm.check_stack('pg_acm.create_schema') then
     raise exception 'You are not allowed to create schemas: please connect as a database/account owner';
   end if;
   if length(p_schema_name)>54 then
@@ -75,4 +75,4 @@ BEGIN
 END;
 $create_schema$
 language plpgsql security definer;
-revoke execute on function acm_tools.create_schema_sd from public;
+revoke execute on function pg_acm.create_schema_sd from public;

--- a/sql/functions/drop_schema_roles_sd.sql
+++ b/sql/functions/drop_schema_roles_sd.sql
@@ -1,4 +1,4 @@
-create or replace function acm_tools.drop_schema_roles_sd(
+create or replace function pg_acm.drop_schema_roles_sd(
   p_schema_name text)
     returns text
     language 'plpgsql' security definer
@@ -10,7 +10,7 @@ v_schema_owner text=p_schema_name||'_owner';
 v_read_only_role text:=p_schema_name||'_read_only';
 v_read_write_role text:=p_schema_name||'_read_write';
 begin
-  if not acm_tools.check_stack('acm_tools.drop_roles_for_schema')
+  if not pg_acm.check_stack('pg_acm.drop_roles_for_schema')
   then
   raise exception 'you are not allowed to drop schema %', p_schema_name;
 end if;
@@ -43,5 +43,4 @@ return v_sql;
 end;
 $body$;
 
-revoke execute on function acm_tools.drop_schema_roles_sd(text) from public;
-
+revoke execute on function pg_acm.drop_schema_roles_sd(text) from public;

--- a/sql/functions/enable_security.sql
+++ b/sql/functions/enable_security.sql
@@ -1,4 +1,4 @@
-create or replace function acm_tools.enable_security(p_drop_trigger boolean default true)
+create or replace function pg_acm.enable_security(p_drop_trigger boolean default true)
 returns text language plpgsql as
 $body$
 declare
@@ -9,55 +9,55 @@ if p_drop_trigger then
   execute $trg$
   drop event trigger if exists fix_owner_grants;
   drop event trigger if exists create_roles_for_schema;
-  drop event trigger if exists drop_roles_for_schema;   
+  drop event trigger if exists drop_roles_for_schema;
   create event trigger fix_owner_grants
      on ddl_command_end
      when tag in ('CREATE TABLE','CREATE TABLE AS','CREATE VIEW', 'CREATE MATERIALIZED VIEW',
      'CREATE SEQUENCE', 'CREATE FUNCTION', 'CREATE PROCEDURE', 'CREATE TYPE', 'CREATE FOREIGN TABLE')
-       execute function acm_tools.fix_owner_grants();
-  
-  create event trigger create_roles_for_schema 
+       execute function pg_acm.fix_owner_grants();
+
+  create event trigger create_roles_for_schema
      on ddl_command_end
      when tag in ('CREATE SCHEMA')
-        execute function acm_tools.create_roles_for_schema();
-  
-  create event trigger drop_roles_for_schema 
+        execute function pg_acm.create_roles_for_schema();
+
+  create event trigger drop_roles_for_schema
      on sql_drop
      when tag in ('DROP SCHEMA')
-        execute function acm_tools.drop_roles_for_schema();
+        execute function pg_acm.drop_roles_for_schema();
   $trg$;
 end if;
 v_db_owner:=(select
                 pg_catalog.pg_get_userbyid(d.datdba)
              from pg_catalog.pg_database d
              where d.datname =current_database());
-v_sql:= $$grant execute on function acm_tools.create_cust_account to $$||v_db_owner||$$;$$;
+v_sql:= $$grant execute on function pg_acm.create_cust_account to $$||v_db_owner||$$;$$;
 
-v_sql:=v_sql||$$grant usage on schema acm_tools to $$||v_db_owner||$$;
-grant execute on function acm_tools.check_stack to $$||v_db_owner||$$;
-grant execute on function acm_tools.create_schema to $$||v_db_owner||$$;
-grant execute on function acm_tools.create_schema_sd to $$||v_db_owner||$$;
-grant execute on function acm_tools.drop_schema_roles_sd to $$||v_db_owner||$$;
-grant execute on function acm_tools.assign_schema_role to $$||v_db_owner||$$;
-grant execute on function acm_tools.assign_schema_role_sd to $$||v_db_owner||$$;
-grant execute on function acm_tools.create_role to $$||v_db_owner||$$;
-grant execute on function acm_tools.create_role_for_schema to $$||v_db_owner||$$;
-grant execute on function acm_tools.assign_schema_app_role to $$||v_db_owner||$$;
-grant execute on function acm_tools.assign_account_role to $$||v_db_owner||$$;
-grant execute on function acm_tools.assign_schema_schema_owner_role to $$||v_db_owner||$$;
-grant execute on function acm_tools.assign_schema_ro_role to $$||v_db_owner||$$;
-grant execute on function acm_tools.revoke_role to $$||v_db_owner||$$;
-grant execute on function acm_tools.revoke_role_sd to $$||v_db_owner||$$;
-grant execute on function acm_tools.revoke_schema_app_role to $$||v_db_owner||$$;
-grant execute on function acm_tools.revoke_schema_schema_owner_role to $$||v_db_owner||$$;
-grant execute on function acm_tools.revoke_schema_ro_role to $$||v_db_owner||$$;
-grant execute on function acm_tools.check_schema_perm to $$||v_db_owner||$$;
-grant execute on function acm_tools.assign_role(text, text, text) to $$||v_db_owner||$$;
-grant execute on function acm_tools.terminate_process to $$||v_db_owner;
+v_sql:=v_sql||$$grant usage on schema pg_acm to $$||v_db_owner||$$;
+grant execute on function pg_acm.check_stack to $$||v_db_owner||$$;
+grant execute on function pg_acm.create_schema to $$||v_db_owner||$$;
+grant execute on function pg_acm.create_schema_sd to $$||v_db_owner||$$;
+grant execute on function pg_acm.drop_schema_roles_sd to $$||v_db_owner||$$;
+grant execute on function pg_acm.assign_schema_role to $$||v_db_owner||$$;
+grant execute on function pg_acm.assign_schema_role_sd to $$||v_db_owner||$$;
+grant execute on function pg_acm.create_role to $$||v_db_owner||$$;
+grant execute on function pg_acm.create_role_for_schema to $$||v_db_owner||$$;
+grant execute on function pg_acm.assign_schema_app_role to $$||v_db_owner||$$;
+grant execute on function pg_acm.assign_account_role to $$||v_db_owner||$$;
+grant execute on function pg_acm.assign_schema_schema_owner_role to $$||v_db_owner||$$;
+grant execute on function pg_acm.assign_schema_ro_role to $$||v_db_owner||$$;
+grant execute on function pg_acm.revoke_role to $$||v_db_owner||$$;
+grant execute on function pg_acm.revoke_role_sd to $$||v_db_owner||$$;
+grant execute on function pg_acm.revoke_schema_app_role to $$||v_db_owner||$$;
+grant execute on function pg_acm.revoke_schema_schema_owner_role to $$||v_db_owner||$$;
+grant execute on function pg_acm.revoke_schema_ro_role to $$||v_db_owner||$$;
+grant execute on function pg_acm.check_schema_perm to $$||v_db_owner||$$;
+grant execute on function pg_acm.assign_role(text, text, text) to $$||v_db_owner||$$;
+grant execute on function pg_acm.terminate_process to $$||v_db_owner;
 
 execute v_sql;
 return v_sql;
 end;
 $body$;
 
-revoke execute on function acm_tools.enable_security from public;
+revoke execute on function pg_acm.enable_security from public;

--- a/sql/functions/revoke_role.sql
+++ b/sql/functions/revoke_role.sql
@@ -1,14 +1,14 @@
-drop function if exists acm_tools.revoke_role(text, text, text);
+drop function if exists pg_acm.revoke_role(text, text, text);
 
-create or replace function acm_tools.revoke_role (p_schema_name text, p_role text, p_srv_user text)
+create or replace function pg_acm.revoke_role (p_schema_name text, p_role text, p_srv_user text)
 returns text
 language plpgsql as
 --security invoker
 $si$
 declare v_sql text;
 begin
-  if acm_tools.check_schema_perm(p_schema_name) then
-    select acm_tools.revoke_role_sd (
+  if pg_acm.check_schema_perm(p_schema_name) then
+    select pg_acm.revoke_role_sd (
             p_schema_name,
             p_role,
             p_srv_user) into v_sql;
@@ -17,4 +17,4 @@ begin
      raise exception 'You are not allowed to manage roles in schema %', p_schema_name;
  end if;
 end; $si$;
-revoke execute on function acm_tools.revoke_role from public;
+revoke execute on function pg_acm.revoke_role from public;

--- a/sql/functions/revoke_role_sd.sql
+++ b/sql/functions/revoke_role_sd.sql
@@ -1,6 +1,6 @@
-drop function if exists acm_tools.revoke_role_sd(text, text, text);
+drop function if exists pg_acm.revoke_role_sd(text, text, text);
 
-create or replace function acm_tools.revoke_role_sd (
+create or replace function pg_acm.revoke_role_sd (
   p_schema_name text,
   p_role text,
   p_srv_user text)
@@ -9,10 +9,10 @@ as
 $func$
 declare
   v_sql text;
-  v_role_name text; 
+  v_role_name text;
   v_cnt int;
 begin
-   if not acm_tools.check_stack('acm_tools.revoke_role')
+   if not pg_acm.check_stack('pg_acm.revoke_role')
      then
      raise exception 'you are not allowed to manage roles in schema %', p_schema_name;
   end if;
@@ -28,4 +28,4 @@ end;
 $func$
 language plpgsql security definer;
 
-revoke execute on function acm_tools.revoke_role_sd from public;
+revoke execute on function pg_acm.revoke_role_sd from public;

--- a/sql/functions/revoke_schema_app_role.sql
+++ b/sql/functions/revoke_schema_app_role.sql
@@ -1,4 +1,4 @@
-create or replace function acm_tools.revoke_schema_app_role (p_schema_name text,
+create or replace function pg_acm.revoke_schema_app_role (p_schema_name text,
 p_srv_user text)
 RETURNS text
 AS
@@ -6,11 +6,10 @@ $func$
 declare
 v_sql text;
 BEGIN
- select acm_tools.revoke_role(p_schema_name,'read_write', p_srv_user)
+ select pg_acm.revoke_role(p_schema_name,'read_write', p_srv_user)
  into v_sql;
 return v_sql;
 END;
 $func$
 language plpgsql;
-revoke execute on function acm_tools.revoke_schema_app_role from public;
-
+revoke execute on function pg_acm.revoke_schema_app_role from public;

--- a/sql/functions/revoke_schema_ro_role.sql
+++ b/sql/functions/revoke_schema_ro_role.sql
@@ -1,15 +1,15 @@
-create or replace function acm_tools.revoke_schema_ro_role (p_schema_name text,
+create or replace function pg_acm.revoke_schema_ro_role (p_schema_name text,
 p_srv_user text)
 RETURNS text
 AS
 $func$
 declare v_sql text;
 BEGIN
- select acm_tools.revoke_role(p_schema_name,'read_only', p_srv_user)
+ select pg_acm.revoke_role(p_schema_name,'read_only', p_srv_user)
  into v_sql;
 return v_sql;
 
 END;
 $func$
 language plpgsql;
-revoke execute on function acm_tools.revoke_schema_ro_role from public;
+revoke execute on function pg_acm.revoke_schema_ro_role from public;

--- a/sql/functions/revoke_schema_schema_owner_role.sql
+++ b/sql/functions/revoke_schema_schema_owner_role.sql
@@ -1,6 +1,6 @@
-drop function if exists acm_tools.revoke_schema_schema_owner_role (text, text);
+drop function if exists pg_acm.revoke_schema_schema_owner_role (text, text);
 
-create or replace function acm_tools.revoke_schema_schema_owner_role (
+create or replace function pg_acm.revoke_schema_schema_owner_role (
   p_schema_name text,
   p_srv_user text)
 returns text
@@ -9,11 +9,11 @@ $func$
 declare
 v_sql text;
 begin
- select acm_tools.revoke_role(p_schema_name,'schema_owner', p_srv_user)
+ select pg_acm.revoke_role(p_schema_name,'schema_owner', p_srv_user)
  into v_sql;
 return v_sql;
 end;
 $func$
 language plpgsql;
 
-revoke execute on function acm_tools.revoke_schema_schema_owner_role from public;
+revoke execute on function pg_acm.revoke_schema_schema_owner_role from public;

--- a/sql/functions/terminate_process.sql
+++ b/sql/functions/terminate_process.sql
@@ -1,4 +1,4 @@
-create or replace function acm_tools.terminate_process(p_pid int)
+create or replace function pg_acm.terminate_process(p_pid int)
 returns boolean
 language plpgsql
 security definer as
@@ -14,7 +14,7 @@ if v_usename is null
    or v_usename in ('autocat', 'drwdba_owner', 'nagios', 'postgres')
  then return false;
  end if;
- insert into acm_tools.killed_processes
+ insert into pg_acm.killed_processes
     (pid,
      usename,
      query,
@@ -26,4 +26,4 @@ if v_usename is null
  return pg_terminate_backend(p_pid);
  end;
  $function$;
- revoke execute on function acm_tools.terminate_process(p_pid int) from public;
+ revoke execute on function pg_acm.terminate_process(p_pid int) from public;

--- a/sql/packages/list_users_privs.sql
+++ b/sql/packages/list_users_privs.sql
@@ -1,23 +1,23 @@
-drop type if exists acm_tools.users cascade;
-create type acm_tools.users as (
+drop type if exists pg_acm.users cascade;
+create type pg_acm.users as (
 user_name text,
 max_connections integer
 );
 
-drop type if exists acm_tools.schema_roles_record cascade;
-create type acm_tools.schema_roles_record as(
+drop type if exists pg_acm.schema_roles_record cascade;
+create type pg_acm.schema_roles_record as(
 schema_name text,
 schema_owner text,
-owner_users acm_tools.users[],
+owner_users pg_acm.users[],
 read_only_role text,
-read_users acm_tools.users[],
+read_users pg_acm.users[],
 read_write_role text,
-app_users acm_tools.users[]
+app_users pg_acm.users[]
 );
 
---select * from acm_tools.list_schemas_roles_flat ()
-create or replace function acm_tools.list_schemas_roles_flat ()
-returns setof acm_tools.schema_roles_record
+--select * from pg_acm.list_schemas_roles_flat ()
+create or replace function pg_acm.list_schemas_roles_flat ()
+returns setof pg_acm.schema_roles_record
 language plpgsql
 as
 $body$
@@ -39,7 +39,7 @@ r.rolname::text as schema_owner,
     join x on m.member = x.role
   )
   select array_agg(row(member,
-  rolconnlimit )::acm_tools.users)
+  rolconnlimit )::pg_acm.users)
   from x
    join pg_roles pr on
    x.member::text=pr.rolname::text
@@ -64,7 +64,7 @@ end as read_only_role,
     join x on m.member = x.role
   )
   select array_agg(row(member,
-  rolconnlimit )::acm_tools.users)
+  rolconnlimit )::pg_acm.users)
   from x
    join pg_roles pr on
    x.member::text=pr.rolname::text
@@ -89,7 +89,7 @@ end as read_write_role,
     join x on m.member = x.role
   )
   select array_agg(row(member,
-  rolconnlimit )::acm_tools.users)
+  rolconnlimit )::pg_acm.users)
   from x
    join pg_roles pr on
    x.member::text=pr.rolname::text
@@ -100,21 +100,21 @@ from pg_namespace s
 join pg_roles r
 on r.oid=s.nspowner
 where nspacl is not null
-and  nspname not in ('pg_catalog', 'information_schema', 'acm_tools', 'public')
+and  nspname not in ('pg_catalog', 'information_schema', 'pg_acm', 'public')
 order by nspname;
 end;
 $body$;
 
 
---select to_json(acm_tools.list_schemas_roles ())
-create or replace function acm_tools.list_schemas_roles ()
-returns  acm_tools.schema_roles_record[]
+--select to_json(pg_acm.list_schemas_roles ())
+create or replace function pg_acm.list_schemas_roles ()
+returns  pg_acm.schema_roles_record[]
 language plpgsql
 as
 $body$
 declare
 v_sql text;
-v_result acm_tools.schema_roles_record[];
+v_result pg_acm.schema_roles_record[];
 begin
 v_sql:= $$select array_agg(
 row(s.nspname::text ,
@@ -133,7 +133,7 @@ r.rolname::text ,
     join x on m.member = x.role
   )
   select array_agg(row(member,
-  rolconnlimit )::acm_tools.users)
+  rolconnlimit )::pg_acm.users)
   from x
    join pg_roles pr on
    x.member::text=pr.rolname::text
@@ -158,7 +158,7 @@ end ,
     join x on m.member = x.role
   )
   select array_agg(row(member,
-  rolconnlimit )::acm_tools.users)
+  rolconnlimit )::pg_acm.users)
   from x
    join pg_roles pr on
    x.member::text=pr.rolname::text
@@ -183,26 +183,26 @@ end,
     join x on m.member = x.role
   )
   select array_agg(row(member,
-  rolconnlimit )::acm_tools.users)
+  rolconnlimit )::pg_acm.users)
   from x
    join pg_roles pr on
    x.member::text=pr.rolname::text
   where  x.role::text= s.nspname||'_read_write'
   and pr.rolcanlogin is true
-  ))::acm_tools.schema_roles_record)
+  ))::pg_acm.schema_roles_record)
 from pg_namespace s
 join pg_roles r
 on r.oid=s.nspowner
 where nspacl is not null
-and  nspname not in ('pg_catalog', 'information_schema', 'acm_tools', 'public')
+and  nspname not in ('pg_catalog', 'information_schema', 'pg_acm', 'public')
 $$;
 execute v_sql into v_result;
 return  v_result;
 end;
 $body$;
 
-drop type if exists acm_tools.db_privs_record cascade;
-create type acm_tools.db_privs_record as (
+drop type if exists pg_acm.db_privs_record cascade;
+create type pg_acm.db_privs_record as (
    priv_type text,
    object_name text,
    role_user_name name,
@@ -210,8 +210,8 @@ create type acm_tools.db_privs_record as (
    permission text
 );
 
-create or replace function acm_tools.db_direct_privs_select ()
-returns setof acm_tools.db_privs_record
+create or replace function pg_acm.db_direct_privs_select ()
+returns setof pg_acm.db_privs_record
 language plpgsql
 as
 $body$
@@ -279,8 +279,8 @@ where rolname !='postgres'
 ;
 end ;$body$;
 
-create or replace function acm_tools.db_all_privs_select ()
-returns setof acm_tools.db_privs_record
+create or replace function pg_acm.db_all_privs_select ()
+returns setof pg_acm.db_privs_record
 language plpgsql
 as
 $body$
@@ -386,4 +386,3 @@ on ir.roleid=r.oid
 where member::text !='postgres'
 )a;
 end ;$body$;
-

--- a/sql/tables/account_role.sql
+++ b/sql/tables/account_role.sql
@@ -1,3 +1,3 @@
-create table if not exists acm_tools.account_role (
+create table if not exists pg_acm.account_role (
   account_role_name text primary key
 );

--- a/sql/tables/allowed_role.sql
+++ b/sql/tables/allowed_role.sql
@@ -1,3 +1,3 @@
-create table if not exists acm_tools.allowed_role (
+create table if not exists pg_acm.allowed_role (
   role_name text primary key
 );

--- a/sql/tables/killed_processes.sql
+++ b/sql/tables/killed_processes.sql
@@ -1,4 +1,4 @@
-create table if not exists acm_tools.killed_processes (
+create table if not exists pg_acm.killed_processes (
   pid int,
   usename text,
   query text,

--- a/tests/01_permissions_test.sql
+++ b/tests/01_permissions_test.sql
@@ -13,7 +13,7 @@ SET client_min_messages TO WARNING;
 
 CREATE EXTENSION pgtap;
 
-SELECT * FROM acm_tools.enable_security();
+SELECT * FROM pg_acm.enable_security();
 
 BEGIN;
 alter event trigger fix_owner_grants disable;
@@ -23,42 +23,42 @@ set role test_db_admin;
 ---create account---
 
 select lives_ok($$
-select * from acm_tools.create_cust_account ('acct1');
+select * from pg_acm.create_cust_account ('acct1');
 $$,'create customer account acct1');
 
 select has_role ('acct1_owner', 'Role acct1_owner was created');
 
-select function_privs_are ('acm_tools', 'create_schema_sd', array['text', 'text','boolean'], 'acct1_owner', array['EXECUTE'], 'acct1_owner should execute acm_tools.create_schema_roles_sd');
-select function_privs_are ('acm_tools','check_schema_perm' , array['text'], 'acct1_owner', array['EXECUTE'], 'acct1_owner should execute acm_tools.create_schema_roles');
-select function_privs_are ('acm_tools','check_stack' , array['text'], 'acct1_owner', array['EXECUTE'], 'acct1_owner should execute acm_tools.check_stack');
-select function_privs_are ('acm_tools','creat_role_for_schema' , array['text','boolean','boolean','boolean','boolean','boolean'], 'acct1_owner', array['EXECUTE'], 'acct1_owner should execute acm_tools.drop_schema_roles');
-select function_privs_are ('acm_tools','drop_schema_roles_sd' , array['text'], 'acct1_owner', array['EXECUTE'], 'acct1_owner should execute acm_tools.drop_schema_roles_sd');
-select function_privs_are ('acm_tools','assign_schema_role' , array['text','text','text','text','boolean'], 'acct1_owner', array['EXECUTE'], 'acct1_owner should execute acm_tools.assign_schema_role');
-select function_privs_are ('acm_tools','assign_schema_role_sd' , array['text','text','text','text','boolean'], 'acct1_owner', array['EXECUTE'], 'acct1_owner should execute acm_tools.assign_schema_role_sd');
-select function_privs_are ('acm_tools','revoke_role' , array['text','text','text'], 'acct1_owner', array['EXECUTE'], 'acct1_owner should execute acm_tools.revoke_role');
-select function_privs_are ('acm_tools','revoke_role_sd' , array['text','text','text'], 'acct1_owner', array['EXECUTE'], 'acct1_owner should execute acm_tools.revoke_role_sd');
-select function_privs_are ('acm_tools','assign_schema_app_role' , array['text','text','text','boolean'], 'acct1_owner', array['EXECUTE'], 'acct1_owner should execute acm_tools.assign_schema_app_role');
-select function_privs_are ('acm_tools','assign_schema_schema_owner_role' , array['text','text','text','boolean'], 'acct1_owner', array['EXECUTE'], 'acct1_owner should execute acm_tools.assign_schema_schema_owner_role');
-select function_privs_are ('acm_tools','assign_schema_ro_role' , array['text','text','text','boolean'], 'acct1_owner', array['EXECUTE'], 'acct1_owner should execute acm_tools.assign_schema_ro_role');
-select function_privs_are ('acm_tools','revoke_schema_app_role' , array['text','text'], 'acct1_owner', array['EXECUTE'], 'acct1_owner should execute acm_tools.revoke_schema_app_role');
-select function_privs_are ('acm_tools','revoke_schema_schema_owner_role' , array['text','text'], 'acct1_owner', array['EXECUTE'], 'acct1_owner should execute acm_tools.revoke_schema_schema_owner_role');
-select function_privs_are ('acm_tools','revoke_schema_ro_role' , array['text','text'], 'acct1_owner', array['EXECUTE'], 'acct1_owner should execute acm_tools.revoke_schema_ro_role');
+select function_privs_are ('pg_acm', 'create_schema_sd', array['text', 'text','boolean'], 'acct1_owner', array['EXECUTE'], 'acct1_owner should execute pg_acm.create_schema_roles_sd');
+select function_privs_are ('pg_acm','check_schema_perm' , array['text'], 'acct1_owner', array['EXECUTE'], 'acct1_owner should execute pg_acm.create_schema_roles');
+select function_privs_are ('pg_acm','check_stack' , array['text'], 'acct1_owner', array['EXECUTE'], 'acct1_owner should execute pg_acm.check_stack');
+select function_privs_are ('pg_acm','creat_role_for_schema' , array['text','boolean','boolean','boolean','boolean','boolean'], 'acct1_owner', array['EXECUTE'], 'acct1_owner should execute pg_acm.drop_schema_roles');
+select function_privs_are ('pg_acm','drop_schema_roles_sd' , array['text'], 'acct1_owner', array['EXECUTE'], 'acct1_owner should execute pg_acm.drop_schema_roles_sd');
+select function_privs_are ('pg_acm','assign_schema_role' , array['text','text','text','text','boolean'], 'acct1_owner', array['EXECUTE'], 'acct1_owner should execute pg_acm.assign_schema_role');
+select function_privs_are ('pg_acm','assign_schema_role_sd' , array['text','text','text','text','boolean'], 'acct1_owner', array['EXECUTE'], 'acct1_owner should execute pg_acm.assign_schema_role_sd');
+select function_privs_are ('pg_acm','revoke_role' , array['text','text','text'], 'acct1_owner', array['EXECUTE'], 'acct1_owner should execute pg_acm.revoke_role');
+select function_privs_are ('pg_acm','revoke_role_sd' , array['text','text','text'], 'acct1_owner', array['EXECUTE'], 'acct1_owner should execute pg_acm.revoke_role_sd');
+select function_privs_are ('pg_acm','assign_schema_app_role' , array['text','text','text','boolean'], 'acct1_owner', array['EXECUTE'], 'acct1_owner should execute pg_acm.assign_schema_app_role');
+select function_privs_are ('pg_acm','assign_schema_schema_owner_role' , array['text','text','text','boolean'], 'acct1_owner', array['EXECUTE'], 'acct1_owner should execute pg_acm.assign_schema_schema_owner_role');
+select function_privs_are ('pg_acm','assign_schema_ro_role' , array['text','text','text','boolean'], 'acct1_owner', array['EXECUTE'], 'acct1_owner should execute pg_acm.assign_schema_ro_role');
+select function_privs_are ('pg_acm','revoke_schema_app_role' , array['text','text'], 'acct1_owner', array['EXECUTE'], 'acct1_owner should execute pg_acm.revoke_schema_app_role');
+select function_privs_are ('pg_acm','revoke_schema_schema_owner_role' , array['text','text'], 'acct1_owner', array['EXECUTE'], 'acct1_owner should execute pg_acm.revoke_schema_schema_owner_role');
+select function_privs_are ('pg_acm','revoke_schema_ro_role' , array['text','text'], 'acct1_owner', array['EXECUTE'], 'acct1_owner should execute pg_acm.revoke_schema_ro_role');
 
 select lives_ok($$
-select * from acm_tools.assign_account_role('acct1', 'acct_user1', 'acct1');
+select * from pg_acm.assign_account_role('acct1', 'acct_user1', 'acct1');
 $$, 'create acct_user1 for acct1');
 
 select lives_ok($$
-select * from acm_tools.assign_account_role('acct1', 'acct_user1', 'acct2');
+select * from pg_acm.assign_account_role('acct1', 'acct_user1', 'acct2');
 $$, 'change password for acct_user1');
 
 select is_member_of ('acct1_owner','acct_user1', 'User acct_user1 has acct1_owner role');
 
 select lives_ok($$
-select * from acm_tools.create_cust_account ('acct2');
+select * from pg_acm.create_cust_account ('acct2');
 $$,'create customer account acct2');
 select lives_ok($$
-select * from acm_tools.assign_account_role('acct2', 'acct_user2', 'acct2');
+select * from pg_acm.assign_account_role('acct2', 'acct_user2', 'acct2');
 $$, 'create acct_user2 for acct2');
 
 select lives_ok($$set role acct1_owner;$$,'role set to acct1_owner');
@@ -84,20 +84,20 @@ select lives_ok($$drop schema acct2_schema2;$$, 'drop acct2_schema2 schema with 
 
 select lives_ok($$create schema acct2_schema3;$$, 'create schema acct2_schema3 schema without using sd-function');
 
-select lives_ok($$select * from acm_tools.assign_schema_schema_owner_role('acct2_schema3', 'owner23_user', 'pwd')$$,
+select lives_ok($$select * from pg_acm.assign_schema_schema_owner_role('acct2_schema3', 'owner23_user', 'pwd')$$,
 'create schema owner user for schema acct2_schema3');
 
-select lives_ok($$select * from acm_tools.assign_schema_app_role('acct2_schema3', 'app23_user', 'pwd')$$,
+select lives_ok($$select * from pg_acm.assign_schema_app_role('acct2_schema3', 'app23_user', 'pwd')$$,
 'create schema app user for schema acct2_schema3');
 
-select lives_ok ($$select * from acm_tools.assign_schema_ro_role('acct2_schema3', 'ro23_user', 'pwd');$$, 'create ro user ro23_user for schema acct2_schema3');
+select lives_ok ($$select * from pg_acm.assign_schema_ro_role('acct2_schema3', 'ro23_user', 'pwd');$$, 'create ro user ro23_user for schema acct2_schema3');
 
 select throws_ok($$drop schema acct1_schema2;$$,'42501', 'must be owner of schema acct1_schema2', 'You are not allowed to drop schema acct1_schema2') ;
 
-select throws_ok($$select * from acm_tools.assign_schema_app_role('acct2_schema1', 'app21_user');$$, 'P0001','NULL password for new user: app21_user',
+select throws_ok($$select * from pg_acm.assign_schema_app_role('acct2_schema1', 'app21_user');$$, 'P0001','NULL password for new user: app21_user',
 $e$NULL password for new user: app21_user$e$);
 
-select lives_ok($$select * from acm_tools.assign_schema_app_role
+select lives_ok($$select * from pg_acm.assign_schema_app_role
 ('acct2_schema1', 'app21_user', 'passwd2');$$, $$create app user app21_user for acct2_schema1$$);
 
 set role postgres;
@@ -106,7 +106,7 @@ create temporary table acct_password as select rolpassword from pg_authid where 
 
 set role acct_user2;
 
-select lives_ok($$select * from acm_tools.assign_schema_app_role
+select lives_ok($$select * from pg_acm.assign_schema_app_role
 ('acct2_schema1', 'app21_user', 'passwd3');$$, $$Change password for user app21_user$$);
 
 set role postgres;
@@ -122,28 +122,28 @@ create temporary table acct_search_path as select substr (settings,13) as search
 SELECT is( 'acct2_schema3, public', (select search_path from acct_search_path), 'Search_path was set up correctly');
 
 set role acct_user2;
-select lives_ok ($$select * from acm_tools.assign_schema_ro_role('acct2_schema1', 'ro23_user', null, false );$$, 'assign acct2_schema1 read role to ro23_user with no path change');
+select lives_ok ($$select * from pg_acm.assign_schema_ro_role('acct2_schema1', 'ro23_user', null, false );$$, 'assign acct2_schema1 read role to ro23_user with no path change');
 
 set role postgres;
 
 select is(substr (settings,13), (select search_path from acct_search_path), $$Search_path didn't change$$)
   from (select usename, unnest(useconfig) as settings from pg_shadow) a
   where substr (settings, 1, 12) ='search_path=' and usename ='ro23_user';
-  
+
 select lives_ok($$set role acct_user1$$,'role set to acct_user1');
 
-select lives_ok($$select * from acm_tools.assign_schema_schema_owner_role
+select lives_ok($$select * from pg_acm.assign_schema_schema_owner_role
 ('acct1_schema1', 'acc_owner_user11', 'passwd1');$$, $$create owner user acc_owner_user11 for acct1_schema1$$);
 
-select throws_ok($$select * from acm_tools.revoke_schema_app_role
+select throws_ok($$select * from pg_acm.revoke_schema_app_role
 ('acct2_schema1', 'app21_user');$$, 'P0001','You are not allowed to manage roles in schema acct2_schema1', $$You are not allowed to manage roles in schema acct2_schema1$$);
 
 select lives_ok($$set role acct_user2;$$,'role set to acct_user2');
 
-select lives_ok($$select * from acm_tools.revoke_schema_app_role
+select lives_ok($$select * from pg_acm.revoke_schema_app_role
 ('acct2_schema1', 'app21_user');$$, $$revoke read_write role on schema acct2_schema1 from app21_user$$);
 
-select lives_ok($$select * from acm_tools.assign_schema_app_role
+select lives_ok($$select * from pg_acm.assign_schema_app_role
 ('acct2_schema1', 'app21_user');$$, $$assign app user role  to user app21_user for acct2_schema1$$);
 
 select lives_ok($$set role owner23_user;$$,'role set to owner23_user');
@@ -163,9 +163,9 @@ select lives_ok($$set role app23_user;$$,'role set to app23_user');
 
 select lives_ok($$insert into acct2_schema3.table231 values (1,2);$$,
  'user app23_user can insert into tables in schema acct2_schema3');
- 
+
 select lives_ok($$truncate table acct2_schema3.table231;$$,
- 'user app23_user can truncate tables in schema acct2_schema3'); 
+ 'user app23_user can truncate tables in schema acct2_schema3');
 
 select lives_ok($$set role ro23_user;$$,'role set to ro23_user');
 


### PR DESCRIPTION
The project is called `pg_acm`, so should the schema not have the same name to avoid confusion?